### PR TITLE
Fix improper hasUntappedLand call

### DIFF
--- a/api/decklist/cards.js
+++ b/api/decklist/cards.js
@@ -91,6 +91,20 @@ const evolvingWilds = (id) => ({
     text: '{T}, Sacrifice Evolving Wilds: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.',
 });
 
+const fieldOfRuin = (id) => ({
+    name: `Field of Ruin ${id}`,
+    type: ['Land'],
+    colors: ['C'],
+    etbTapped: () => false,
+});
+
+const darkslickShores = (id) => ({
+    name: `Darkslick Shores ${id}`,
+    type: ['Land'],
+    colors: ['U', 'B'],
+    etbTapped: (lands, cmc) => lands.length > 3 && cmc > 3
+});
+
 const growthSpiral = (id) => ({
     name: `Growth Spiral ${id}`,
     type: ['spell'],
@@ -351,6 +365,8 @@ module.exports = {
     simicGuildGate,
     fabledPassage,
     evolvingWilds,
+    fieldOfRuin,
+    darkslickShores,
     prismaticVista,
     mistyRainforest,
     bloodstainedMire,

--- a/api/decklist/cards/utils.js
+++ b/api/decklist/cards/utils.js
@@ -200,7 +200,7 @@ function evaluateCost(lands, cost, cmc) {
             colorsToFind[color]--;
         }
     });
-    return Object.values(colorsToFind).every((l) => l === 0) && hasUntappedLand(usedLands, cmc);
+    return Object.values(colorsToFind).every((l) => l === 0) && hasUntappedLand(usedLands, { cmc });
 }
 
 function canPlaySpellOnCurve(lands, spell) {

--- a/api/decklist/tests/manacost.unit.test.js
+++ b/api/decklist/tests/manacost.unit.test.js
@@ -7,6 +7,8 @@ const {
     saheeli,
     giantGrowth,
     growthSpiral,
+    fieldOfRuin,
+    darkslickShores,
 } = require('../cards');
 const { evaluateCost } = require('../cards/utils');
 
@@ -78,6 +80,20 @@ describe('manacost 1', () => {
         const cost = { 'U/R': 2, generic: 1 };
         const cmc = 3;
         const lands = [volcanicIsland(0), forest(0), forest(1)];
+        expect(evaluateCost(lands, cost, cmc)).toBe(false);
+    });
+
+    it('tapped 4', () => {
+        const cost = { 'B': 4 };
+        const cmc = 4;
+        const lands = [darkslickShores(0), darkslickShores(1), darkslickShores(2), darkslickShores(3)];
+        expect(evaluateCost(lands, cost, cmc)).toBe(false);
+    });
+
+    it('tapped 4 and colorless 1', () => {
+        const cost = { 'B': 4 };
+        const cmc = 4;
+        const lands = [darkslickShores(0), darkslickShores(1), darkslickShores(2), darkslickShores(3), fieldOfRuin(0)];
         expect(evaluateCost(lands, cost, cmc)).toBe(false);
     });
 });


### PR DESCRIPTION
The current implementation of `evaluateCost` does not call correctly the `hasUntappedLand` function resulting in improper evaluation with fast lands (or similar) checking the cmc of the spell to cast, e.g making possible to cast a _Lich_ with 4 _Darkslick Shores_

The `evaluateCost` function has been modified to properly pass the cmc to the `hasUntappedLand` function.

NOTE: this bug rarely happens since the `hasUntappedLand` function is called by `canPlaySpellOnCurve` before, shading the bug.